### PR TITLE
fix find_next_page for bs4 >=4.9.0

### DIFF
--- a/schlabber.py
+++ b/schlabber.py
@@ -24,10 +24,10 @@ class Soup:
     
     def find_next_page(self, cur_page):
         for script in cur_page.find_all('script'):
-            if "SOUP.Endless.next_url" in script.get_text():
+            if script.string and "SOUP.Endless.next_url" in script.string:
                 print("\t...found")
                 self.dlnextfound = True
-                return script.get_text().split('\'')[-2].strip()
+                return script.string.split('\'')[-2].strip()
         self.dlnextfound = False
         return ""
     
@@ -340,6 +340,7 @@ class Soup:
             print("Process Posts")
             self.process_posts(page)
             if self.dlnextfound == False:
+                print("no next found.")
                 break
 
 def main(soups, bup_dir, cont_from):


### PR DESCRIPTION
`find_next_page()` uses `.get_text()` to search the contents of `script` elements, this doesn't work with bs4 versions starting with 4.9.0 according to documentation:

> As of Beautiful Soup version 4.9.0, when lxml or html.parser are in use, the contents of <script>, <style>, and <template> tags are not considered to be ‘text’, since those tags are not part of the human-visible content of the page.
https://www.crummy.com/software/BeautifulSoup/bs4/doc/#get-text

