### PR TITLE
Patch 3

### DIFF
--- a/schlabber.py
+++ b/schlabber.py
@@ -152,6 +152,8 @@ class Soup:
         else:
             meta['body'] = "";
         if 'soup_url' in meta and meta['soup_url'] is not None:
+            if meta['soup_url'].startswith("//"):
+                meta['soup_url'] = "http:" + meta['soup_url']
             basepath = self.bup_dir + self.sep
             if self.has_valid_timestamp(meta):
                 basepath = basepath + meta['time'][2] + self.sep + meta['time'][0] + self.sep

--- a/schlabber.py
+++ b/schlabber.py
@@ -145,7 +145,7 @@ class Soup:
             meta['body'] = bodyelem.get_text().strip()
         else:
             meta['body'] = "";
-        if 'soup_url' in meta:
+        if 'soup_url' in meta and meta['soup_url'] is not None:
             basepath = self.bup_dir + self.sep
             if self.has_valid_timestamp(meta):
                 basepath = basepath + meta['time'][2] + self.sep + meta['time'][0] + self.sep

--- a/schlabber.py
+++ b/schlabber.py
@@ -140,6 +140,12 @@ class Soup:
         video = post.find("div", {'class':'embed'}).find('video')
         if video:
             meta['soup_url'] = video.get("src")
+            if meta['soup_url'] is None and video.find('source'):
+                for source in video.find_all('source'):
+                    src = source.get("src")
+                    # prefer mp4 (as for my example webm returned 404)
+                    if meta['soup_url'] is None or (src is not None and src.endswith(".mp4")):
+                        meta['soup_url'] = src
         bodyelem = post.find("div", {'class':'body'})
         if bodyelem:
             meta['body'] = bodyelem.get_text().strip()


### PR DESCRIPTION
In the mentioned post of #11 the html code has no src attribute on the video element, but contains separate source elements:

```
<video poster="//i.imgur.com/ZTOnjXM.jpg" preload="auto" autoplay="autoplay" muted="muted" loop="loop" webkit-playsinline="" style="width: 500px; height: 280px;">
<source src="//i.imgur.com/ZTOnjXM.webm" type="video/webm">
<source src="//i.imgur.com/ZTOnjXM.mp4" type="video/mp4">
</video>
```

The webm source returned 404, so I a mp4 source is loaded if possible. This is very specific for this case; in general maybe all options should be tried out.

To handle the protocol relative URL I assume http:// will just work / redirect. Otherwise the protocol could be extracted from the loaded site (however, right now the rooturl starts with http:// so there is no difference).